### PR TITLE
Add `noAuthDialog` option to force CLI prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ Default value: `false`
 
 The task will normally prompt you for your password and then store authentication tokens in your home directory using Multipass. It never stores passwords in plaintext. However, if you want to manage your authentication manually instead, you can remove this behavior by setting `noStoreAuth` to `true`.
 
+#### options.noAuthDialog
+Type: `Boolean`
+Default value: `false`
+
+When prompting you for your password, the task will use an OS dialog box where available (on OSX and Windows). To force the task to prompt in the console instead, set `noAuthDialog` to `true`.
+
 #### options.action
 Type: `String`
 Default value: `'upload'`

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
     "humanize": "0.0.9",
     "mozu-appdev-utils": "^1.1.2",
     "mozu-metadata": "^2.3.6",
-    "mozu-multipass": "^0.3.3",
-    "prompt": "^1.0.0"
+    "mozu-multipass": "^0.3.3"
   },
   "devDependencies": {
     "mozu-validate-npm-package": "^1.2.1"

--- a/tasks/mozusync.js
+++ b/tasks/mozusync.js
@@ -12,7 +12,7 @@ var humanize = require('humanize');
 var groupBy = require('group-by');
 var appDevUtils = require('mozu-appdev-utils');
 var Multipass = require('mozu-multipass');
-var prompt = require('prompt');
+var clortho = require('clortho');
 var MozuEnvironments = require('mozu-metadata/data/environments.json');
 var chalk = require('chalk');
 
@@ -28,123 +28,80 @@ function getEnvironmentName(context) {
 
 module.exports = function (grunt) {
 
-  function PromptForPassword(client) {
-    var context = client.context;
-    var username = context.developerAccount.emailAddress;
-    var proto = Multipass(client);
-    var authStorage = Object.create(proto);
-
-    var usernameProps = {
-      name: 'username',
-      required: true,
-      message: 'Developer Account Username'
-    };
-
-    var passwordProps = {
-      required: true,
-      name: 'password',
-      hidden: true,
-      message: 'Developer Account Password'
-    };
-
-    var prompts = [passwordProps];
-
-    if (!username) {
-      prompts.unshift(usernameProps);
-    }
-
-    authStorage.get = function(claimtype, ctx, callback) {
-      prompt.start();
-      prompt.get(prompts, function (err, result) {
-        if (result.username) {
-          ctx.developerAccount.emailAddress = result.username; 
-        }
-
-        if (result.password) {
-          ctx.developerAccount.password = result.password;  
-        }
-
-        callback(null, null);
-      });
-    };
-
-    return client.authenticationStorage = authStorage;
-  }
-
   // hack in case there is an unknown race condition and suffering occurs
   // before the MozuClortho object is created.
-  // var invalidateKeychain = function() { return Promise.resolve(); };
+  var invalidateKeychain = function() { return Promise.resolve(); };
 
-  // function PromptingPass(client) {
-  //   var proto = Multipass(client);
-  //   var o = Object.create(proto);
-  //   o.get = function(claimtype, context, callback) {
-  //     return proto.get.call(this, claimtype, context, function(err, ticket) {
-  //       var username = context.developerAccount.emailAddress;
-  //       var serviceName = 'Mozu AppDev Sync: ' + getEnvironmentName(context);
-  //       var MozuClortho = clortho.forService(serviceName);
-  //       function invalidatePassword() {
-  //         grunt.verbose.ok('Removing invalid saved credential');
-  //         return MozuClortho.removeFromKeychain(username);
-  //       }
-  //       function invalidateTicket() {
-  //         grunt.verbose.ok('Removing invalid auth ticket');
-  //         return new Promise(function(resolve, reject) {
-  //           o.remove(claimtype, context, function(e) {
-  //             if (e) return reject(e);
-  //             return resolve();
-  //           });
-  //         });
-  //       }
-  //       if (claimtype === "developer" && !context.developerAccount.password) {
-  //         invalidateKeychain = invalidateTicket;
-  //         if (!ticket) {
-  //           invalidateKeychain = invalidatePassword;
-  //           MozuClortho.getFromKeychain(username)
-  //           .then(function(credential) {
-  //             grunt.verbose.ok(
-  //               'Found credential for ' + username + ' on ' + serviceName +
-  //                 ' in system keychain. Obtaining new auth ticket...'
-  //             );
-  //             return credential;
-  //           })
-  //           .catch(function() {
-  //             grunt.verbose.ok(
-  //               'Could not find a stored credential for ' + username + ' on ' +
-  //                 serviceName + '. Need authorization to upload.'
-  //             );
-  //             return MozuClortho.prompt(
-  //               username,
-  //               'Enter your password to upload to ' + serviceName + '.'
-  //             );
-  //           })
-  //           .then(function(credential) {
-  //             grunt.verbose.ok(
-  //               'Storing credential in system keychain...'
-  //             );
-  //             return MozuClortho.trySaveToKeychain(credential);
-  //           })
-  //           .catch(function(e) {
-  //             grunt.fail.fatal(
-  //               'Need authorization for ' + serviceName + ' to continue.'
-  //             );
-  //           })
-  //           .then(function(credential) {
-  //             context.developerAccount.emailAddress = credential.username;
-  //             context.developerAccount.password = credential.password;
-  //             callback(null, null);
-  //           });
-  //         } else {
-  //           grunt.verbose.ok('Found stored authentication ticket for ' + username);
-  //           callback(null, ticket);
-  //         }
-  //       } else {
-  //         callback(null, ticket);
-  //       }
-  //     });
-  //   };
-  //   return client.authenticationStorage = o;
-  // };
+  function PromptingPass(client) {
+    var proto = Multipass(client);
+    var o = Object.create(proto);
+    o.get = function(claimtype, context, callback) {
+      return proto.get.call(this, claimtype, context, function(err, ticket) {
+        var username = context.developerAccount.emailAddress;
+        var serviceName = 'Mozu AppDev Sync: ' + getEnvironmentName(context);
+        var MozuClortho = clortho.forService(serviceName);
+        function invalidatePassword() {
+          grunt.verbose.ok('Removing invalid saved credential');
+          return MozuClortho.removeFromKeychain(username);
+        }
+        function invalidateTicket() {
+          grunt.verbose.ok('Removing invalid auth ticket');
+          return new Promise(function(resolve, reject) {
+            o.remove(claimtype, context, function(e) {
+              if (e) return reject(e);
+              return resolve();
+            });
+          });
+        }
+        if (claimtype === "developer" && !context.developerAccount.password) {
+          invalidateKeychain = invalidateTicket;
+          if (!ticket) {
+            invalidateKeychain = invalidatePassword;
+            MozuClortho.getFromKeychain(username)
+            .then(function(credential) {
+              grunt.verbose.ok(
+                'Found credential for ' + username + ' on ' + serviceName +
+                  ' in system keychain. Obtaining new auth ticket...'
+              );
+              return credential;
+            })
+            .catch(function() {
+              grunt.verbose.ok(
+                'Could not find a stored credential for ' + username + ' on ' +
+                  serviceName + '. Need authorization to upload.'
+              );
+              return MozuClortho.prompt(
+                username,
+                'Enter your password to upload to ' + serviceName + '.'
+              );
+            })
+            .then(function(credential) {
+              grunt.verbose.ok(
+                'Storing credential in system keychain...'
+              );
+              return MozuClortho.trySaveToKeychain(credential);
+            })
+            .catch(function(e) {
+              grunt.fail.fatal(
+                'Need authorization for ' + serviceName + ' to continue.'
+              );
+            })
+            .then(function(credential) {
+              context.developerAccount.emailAddress = credential.username;
+              context.developerAccount.password = credential.password;
+              callback(null, null);
+            });
+          } else {
+            grunt.verbose.ok('Found stored authentication ticket for ' + username);
+            callback(null, ticket);
+          }
+        } else {
+          callback(null, ticket);
+        }
+      });
+    };
+    return client.authenticationStorage = o;
+  };
 
   var customErrors = {
     INVALID_CREDENTIALS: 'Invalid credentials. Please re-enter your username and password, and/or check your mozu.config.json file to see that you are using the right developer account ID and environment.'
@@ -271,7 +228,7 @@ module.exports = function (grunt) {
     var context = options.context;
 
     if (!options.noStoreAuth) {
-      plugins = [PromptForPassword];
+      plugins = [PromptingPass];
     }
 
     if (!options.applicationKey) {

--- a/tasks/mozusync.js
+++ b/tasks/mozusync.js
@@ -31,7 +31,6 @@ module.exports = function (grunt) {
   function PromptForPassword(client) {
     var context = client.context;
     var username = context.developerAccount.emailAddress;
-    var password = context.developerAccount.password;
     var proto = Multipass(client);
     var authStorage = Object.create(proto);
 
@@ -48,38 +47,25 @@ module.exports = function (grunt) {
       message: 'Developer Account Password'
     };
 
-    var askForCredentials = function(prompts, ctx) {
-      return prompts.length > 0 && (!ctx.developerAccount.emailAddress || !ctx.developerAccount.password);
-    }
-
-    var prompts = [];
+    var prompts = [passwordProps];
 
     if (!username) {
-      prompts.push(usernameProps);
-    }
-
-    if (!password) {
-      prompts.push(passwordProps);
+      prompts.unshift(usernameProps);
     }
 
     authStorage.get = function(claimtype, ctx, callback) {
-      if (askForCredentials(prompts, ctx)) {
+      prompt.start();
+      prompt.get(prompts, function (err, result) {
+        if (result.username) {
+          ctx.developerAccount.emailAddress = result.username; 
+        }
 
-        prompt.get(prompts, function (err, result) {
-          if (result.username) {
-            ctx.developerAccount.emailAddress = result.username; 
-          }
+        if (result.password) {
+          ctx.developerAccount.password = result.password;  
+        }
 
-          if (result.password) {
-            ctx.developerAccount.password = result.password;  
-          }
-          callback(null, null);
-          prompt.stop();
-        });
-      }
-      else {
         callback(null, null);
-      }
+      });
     };
 
     return client.authenticationStorage = authStorage;

--- a/tasks/mozusync.js
+++ b/tasks/mozusync.js
@@ -45,7 +45,11 @@ module.exports = function (grunt) {
           var MozuClortho = clortho.forService(serviceName);
           function invalidatePassword() {
             grunt.verbose.ok('Removing invalid saved credential');
-            return MozuClortho.removeFromKeychain(username);
+            return MozuClortho.removeFromKeychain(username)
+              .catch(function(e) {
+                grunt.verbose.writeln('Failed to remove from keychain: ' + e);
+                return true;
+              });
           }
           function invalidateTicket() {
             grunt.verbose.ok('Removing invalid auth ticket');


### PR DESCRIPTION
I'm guessing that [this clortho issue](https://github.com/zetlen/clortho/issues/1) is the reason for the last couple of commits in this repo that added password prompting. I haven't been able to fix that issue yet, but there is a good workaround! Password prompting in the terminal is [already part of clortho](https://github.com/zetlen/clortho#promptusername-message-cli), but by default it tries to use an OS dialog in Windows. **There is an option to disable that and force the CLI prompt**, but this plugin didn't support it. This PR adds support for that option.
- Reverted the last two commits, back to v2.2.0
- Added a factory function to make runtime Grunt task options available in plugin constructor
- Added code to bind the `noStoreAuth` task config property to send the `cli` argument into `MozuClortho.prompt`
- Documented new option

![image](https://cloud.githubusercontent.com/assets/1643758/13380287/ab6d2b24-de04-11e5-8fe6-2eb0bfee01f0.png)
